### PR TITLE
feat: add matcher.block to stop event propagation after match

### DIFF
--- a/nonebot_plugin_revoke/__init__.py
+++ b/nonebot_plugin_revoke/__init__.py
@@ -5,6 +5,7 @@ from nonebot.adapters.onebot.v11 import ActionFailed, Bot
 from nonebot.internal.params import Depends
 from nonebot.permission import SUPERUSER
 from nonebot.plugin import PluginMetadata
+from nonebot.matcher import Matcher
 
 from .utils import reply_message_id
 
@@ -23,10 +24,15 @@ revoke_matcher = on_command("revoke", aliases={"撤回"}, permission=SUPERUSER)
 @revoke_matcher.handle()
 async def _(
         bot: Bot,
+        matcher: Matcher,
         reply_msg_id: Optional[int] = Depends(reply_message_id)
 ):
+    
+    matcher.stop_propagation()  # ✨ 阻止其他 matcher（包括其他插件）继续处理
+
     try:
         if reply_msg_id is not None:
             await bot.delete_msg(message_id=reply_msg_id)
+
     except ActionFailed as e:
         logger.exception(e)


### PR DESCRIPTION
让插件在匹配后阻止事件继续传递（防止被其他插件处理）